### PR TITLE
Fix OpenSSF Scorecard alerts: Add --require-hashes flag to pip install commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,19 @@ RUN apt-get update && \
 
 # Copy dependency files
 COPY pyproject.toml README.md LICENSE ./
-COPY requirements.txt ./
+COPY requirements-pip.txt requirements.txt ./
 
 # Create virtual environment and install dependencies
 RUN python -m venv /app/.venv && \
-    /app/.venv/bin/pip install --no-cache-dir pip==25.3 \
-        --hash sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
-        --hash sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd && \
-    /app/.venv/bin/pip install --no-cache-dir -r requirements.txt
+    /app/.venv/bin/pip install --require-hashes --no-cache-dir -r requirements-pip.txt && \
+    /app/.venv/bin/pip install --require-hashes --no-cache-dir -r requirements.txt
 
 # Copy source code
 COPY src ./src
 
 # Install the project (non-editable for production)
-RUN /app/.venv/bin/pip install --no-cache-dir .
+# Use --no-deps to ensure all dependencies are already installed with hash verification
+RUN /app/.venv/bin/pip install --no-cache-dir --no-deps .
 
 # Runtime stage
 FROM python:3.14-slim-bookworm@sha256:e8ea0e4fc6f1876e7d2cfccc0071847534b1d72f2359cf0fd494006d05358faa

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,0 +1,5 @@
+# Pin pip version with hashes for secure installation
+# This file is used in the Dockerfile to upgrade pip with hash verification
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd


### PR DESCRIPTION
## Summary
This PR fixes OpenSSF Scorecard alerts #42, #45, and #46 by ensuring all pip install commands in the Dockerfile use hash verification.

## Changes
- Created `requirements-pip.txt` with pip version and SHA256 hashes
- Updated Dockerfile to use `--require-hashes` flag for both pip and dependencies installation
- Added `--no-deps` flag to local package installation to prevent installation of unverified dependencies

## Technical Details
The OpenSSF Scorecard scanner requires that all `pip install` commands use the `--require-hashes` flag to ensure dependency integrity. This PR addresses three specific issues:

1. **Alert #42**: Local package installation now uses `--no-deps` to ensure no dependencies are installed without hash verification
2. **Alerts #45, #46**: Both pip upgrade and requirements.txt installation now use `--require-hashes` flag

## Test Plan
- [x] Docker build completes successfully
- [x] All pre-commit hooks pass
- [x] CI/CD pipeline passes
- [ ] OpenSSF Scorecard alerts #42, #45, #46 are resolved

## Fixes
Fixes #42
Fixes #45
Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)