### PR TITLE
Fix code scanning alert: Pin npm dependencies by hash in Dockerfile.glama

### DIFF
--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -12,16 +12,23 @@ RUN apt-get update && \
     bash nodesource_setup.sh && \
     rm nodesource_setup.sh && \
     apt-get install -y --no-install-recommends nodejs=24.* && \
-    npm install -g mcp-proxy@5.12.0 pnpm@10.14.0 && \
-    node --version && \
     curl -LsSf https://astral.sh/uv/0.5.14/install.sh -o uv_install.sh && \
     UV_INSTALL_DIR="/usr/local/bin" sh uv_install.sh && \
     rm uv_install.sh && \
     uv python install 3.13 --default --preview && \
     ln -s "$(uv python find)" /usr/local/bin/python && \
     python --version && \
+    node --version && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /var/tmp/*
+
+# Copy npm dependency files for hash-pinned installation
+COPY docker/glama/package.json docker/glama/package-lock.json /tmp/npm-deps/
+
+WORKDIR /tmp/npm-deps
+RUN npm ci --omit=dev && \
+    ln -s /tmp/npm-deps/node_modules/.bin/mcp-proxy /usr/local/bin/mcp-proxy && \
+    ln -s /tmp/npm-deps/node_modules/.bin/pnpm /usr/local/bin/pnpm
 
 WORKDIR /app
 

--- a/docker/glama/package-lock.json
+++ b/docker/glama/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "mcp-toolz-glama-deps",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-toolz-glama-deps",
+      "version": "1.0.0",
+      "dependencies": {
+        "mcp-proxy": "5.12.5",
+        "pnpm": "10.14.0"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "5.12.5",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.12.5.tgz",
+      "integrity": "sha512-Vawdc8vi36fXxKCaDpluRvbGcmrUXJdvXcDhkh30HYsws8XqX2rWPBflZpavzeS+6SwijRFV7g+9ypQRJZlrEQ==",
+      "license": "MIT",
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-10.14.0.tgz",
+      "integrity": "sha512-rSenlkG0nD5IGhaoBbqnGBegS74Go40X5g4urug/ahRsamiBJfV5LkjdW6MOfaUqXNpMOZK5zPMz+c4iOvhHSA==",
+      "license": "MIT",
+      "bin": {
+        "pnpm": "bin/pnpm.cjs",
+        "pnpx": "bin/pnpx.cjs"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    }
+  }
+}

--- a/docker/glama/package.json
+++ b/docker/glama/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-toolz-glama-deps",
+  "version": "1.0.0",
+  "description": "Global npm dependencies for mcp-toolz Glama image",
+  "private": true,
+  "dependencies": {
+    "mcp-proxy": "5.12.5",
+    "pnpm": "10.14.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Resolves security code scanning alert [#56](https://github.com/taylorleese/mcp-toolz/security/code-scanning/56) by pinning npm packages using cryptographic integrity hashes
- Created `docker/glama/package.json` and `docker/glama/package-lock.json` to declare dependencies with SHA-512 integrity hashes
- Updated `Dockerfile.glama` to use `npm ci` instead of `npm install -g` for hash verification
- Upgraded mcp-proxy from 5.12.0 to 5.12.5
- All packages are now verified by cryptographic hash during build, protecting against supply chain attacks

## Test plan
- [x] Docker image builds successfully
- [x] mcp-proxy and pnpm are accessible in the container
- [x] All pre-commit hooks pass (including hadolint)

Fixes https://github.com/taylorleese/mcp-toolz/security/code-scanning/56

🤖 Generated with [Claude Code](https://claude.com/claude-code)