### PR TITLE
Update MCP badge version to 1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mcp-name: io.github.taylorleese/mcp-toolz
 [![codecov](https://codecov.io/gh/taylorleese/mcp-toolz/branch/main/graph/badge.svg)](https://codecov.io/gh/taylorleese/mcp-toolz)
 [![PyPI version](https://img.shields.io/pypi/v/mcp-toolz.svg)](https://pypi.org/project/mcp-toolz/)
 [![Python](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![MCP](https://img.shields.io/badge/MCP-1.23.0-blue)](https://modelcontextprotocol.io)
+[![MCP](https://img.shields.io/badge/MCP-1.25.0-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)


### PR DESCRIPTION
## Summary
- Update MCP badge version from 1.23.0 to 1.25.0 to match dependency in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)