### PR TITLE
Add .trivyignore to suppress protobuf CVE-2026-0994

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy ignore file
+# Documentation: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#by-vulnerability-ids
+
+# CVE-2026-0994: protobuf JSON recursion depth bypass DoS
+# No patched version available yet (affects protobuf <= 6.33.4)
+# Risk accepted temporarily. Monitoring upstream for security patch.
+# Review date: 2026-01-27
+# TODO: Remove this ignore once patched version is released
+CVE-2026-0994


### PR DESCRIPTION
## Summary

Adds `.trivyignore` file to suppress the Trivy code scanning alert for protobuf CVE-2026-0994.

## Background

After merging #81, we still have 2 types of alerts for the protobuf vulnerability:

1. **Trivy code scanning alert #60** - CVE-2026-0994 in requirements.txt
2. **Dependabot alerts #26, #25** - Need manual dismissal (will handle separately)

## Changes

- 📝 Add `.trivyignore` file to suppress CVE-2026-0994 in Trivy scans
- Documents that no patched version is available yet
- Includes TODO to remove once protobuf is patched

## Next Steps After Merge

1. Manually dismiss Dependabot alerts #26 and #25 with reason "No fix available"
2. Wait for OSV-Scanner to run and respect the `osv-scanner.toml` configuration (alert #37)
3. Monitor [protobuf releases](https://github.com/protocolbuffers/protobuf/releases) for security patch

## Related

- Related to #81 (Security fixes and version bump)
- Addresses remaining alerts after the pnpm fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)