### PR TITLE
Update MCP version badge to 1.26.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mcp-name: io.github.taylorleese/mcp-toolz
 [![codecov](https://codecov.io/gh/taylorleese/mcp-toolz/branch/main/graph/badge.svg)](https://codecov.io/gh/taylorleese/mcp-toolz)
 [![PyPI version](https://img.shields.io/pypi/v/mcp-toolz.svg)](https://pypi.org/project/mcp-toolz/)
 [![Python](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![MCP](https://img.shields.io/badge/MCP-1.25.0-blue)](https://modelcontextprotocol.io)
+[![MCP](https://img.shields.io/badge/MCP-1.26.0-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)


### PR DESCRIPTION
## Summary

Updates the MCP version badge in README.md to reflect the correct version (1.26.0) that matches the dependency in pyproject.toml.

## Changes

- Update MCP badge from 1.25.0 → 1.26.0 in README.md:11

## Context

After releasing v0.3.14, noticed the README showed outdated MCP version. The project uses MCP 1.26.0 (as specified in pyproject.toml:36), but the badge was still showing 1.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)