### PR TITLE
Update pre-commit hooks and apply black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   # GENERIC FILE CHECKS
   # ============================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -21,7 +21,7 @@ repos:
   # PYTHON CHECKS
   # ============================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -41,13 +41,13 @@ repos:
         additional_dependencies: [autoflake==2.3.1]
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3.13
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.0
     hooks:
       - id: ruff
         args: [--fix]
@@ -69,7 +69,7 @@ repos:
         additional_dependencies: [flake8==7.1.1]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -86,7 +86,7 @@ repos:
         args: [--config-file=pyproject.toml]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.9.3
     hooks:
       - id: bandit
         args: [-c, pyproject.toml]
@@ -108,13 +108,13 @@ repos:
   # SHELL SCRIPT CHECKS
   # ============================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: [--severity=warning]
@@ -123,24 +123,24 @@ repos:
   # OTHER TOOL CHECKS
   # ============================================================================
   - repo: https://github.com/mrtazz/checkmake
-    rev: 0.2.2
+    rev: v0.3.0
     hooks:
       - id: checkmake
         args: [--config, .checkmake]
 
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
+    rev: v2.14.0
     hooks:
       - id: hadolint-docker
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: [--strict, -d, "{extends: default, rules: {line-length: {max: 140}, document-start: disable}}"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         args: [--fix, --config, .markdownlint.json]

--- a/src/context_manager/storage.py
+++ b/src/context_manager/storage.py
@@ -100,8 +100,7 @@ class ContextStorage:
             # Configure connection for optimal concurrency
             self._configure_connection(conn)
 
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS contexts (
                     id TEXT PRIMARY KEY,
                     timestamp TEXT NOT NULL,
@@ -118,8 +117,7 @@ class ContextStorage:
                     gemini_response TEXT,
                     deepseek_response TEXT
                 )
-            """
-            )
+            """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_type ON contexts(type)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_timestamp ON contexts(timestamp)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_title ON contexts(title COLLATE NOCASE)")
@@ -136,8 +134,7 @@ class ContextStorage:
                 conn.execute("ALTER TABLE contexts ADD COLUMN deepseek_response TEXT")
 
             # Todo snapshots table
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS todo_snapshots (
                     id TEXT PRIMARY KEY,
                     timestamp TEXT NOT NULL,
@@ -150,8 +147,7 @@ class ContextStorage:
                     metadata TEXT,
                     FOREIGN KEY (session_context_id) REFERENCES contexts(id)
                 )
-            """
-            )
+            """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_todo_project ON todo_snapshots(project_path)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_todo_timestamp ON todo_snapshots(timestamp)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_todo_active ON todo_snapshots(is_active)")


### PR DESCRIPTION
## Summary
- Update all pre-commit hooks to latest versions to match requirements-dev.txt
- Apply black formatting to storage.py (multiline SQL statements made more compact)
- All pre-commit hooks passing ✅

## Updated Hooks
- **pre-commit-hooks**: v5.0.0 → v6.0.0
- **black**: 24.10.0 → 26.1.0
- **ruff**: v0.8.4 → v0.15.0
- **mypy**: v1.13.0 → v1.19.1
- **bandit**: 1.7.10 → 1.9.3
- **shellcheck-py**: v0.10.0.1 → v0.11.0.1
- **checkmake**: 0.2.2 → v0.3.0
- **hadolint**: v2.12.0 → v2.14.0
- **yamllint**: v1.35.1 → v1.38.0
- **markdownlint-cli**: v0.43.0 → v0.47.0

## Test plan
- [x] All pre-commit hooks pass
- [x] Black formatting applied successfully
- [x] Hook versions match requirements-dev.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)