### PR TITLE
fix(deps): upgrade pyjwt to 2.12.0 for CVE-2026-32597

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,4 +9,5 @@ urllib3==2.6.3
 
 # Security fixes for transitive dependencies
 pyasn1==0.6.3
+pyjwt[crypto]==2.12.0
 protobuf==5.29.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -745,10 +745,12 @@ pydantic-settings==2.12.0 \
     --hash=sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0 \
     --hash=sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809
     # via mcp
-pyjwt[crypto]==2.10.1 \
-    --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
-    --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
-    # via mcp
+pyjwt[crypto]==2.12.0 \
+    --hash=sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02 \
+    --hash=sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e
+    # via
+    #   -r requirements.in
+    #   mcp
 pyparsing==3.2.5 \
     --hash=sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6 \
     --hash=sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e


### PR DESCRIPTION
## Summary
- Upgrades PyJWT from 2.10.1 to 2.12.0 to fix CVE-2026-32597 (HIGH severity)
- PyJWT 2.10.1 accepts unknown `crit` header extensions in violation of RFC 7515 §4.1.11
- Pins `pyjwt[crypto]==2.12.0` in `requirements.in` as a transitive dependency security fix (via `mcp`)

## Test plan
- [x] `make compile-requirements` regenerated `requirements.txt` with updated hashes
- [x] `make test` — all 35 tests pass
- [x] Pre-commit hooks pass (including pip-audit and pipdeptree)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)