### PR TITLE
ci: add weekly resolve-github-alerts workflow

### DIFF
--- a/.github/workflows/resolve-github-alerts.yml
+++ b/.github/workflows/resolve-github-alerts.yml
@@ -1,0 +1,57 @@
+name: Resolve GitHub Security Alerts
+
+"on":
+  schedule:
+    # Saturday 09:00 America/Los_Angeles during PDT (16:00 UTC).
+    # During PST (winter), this runs at 08:00 local — cron is fixed UTC.
+    - cron: '0 16 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: resolve-github-alerts
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve alerts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      security-events: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RESOLVE_ALERTS_PAT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --require-hashes --no-cache-dir -r requirements-pip.txt
+          pip install --require-hashes --no-cache-dir -r requirements-dev.txt
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run /resolve-github-alerts
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: claude-opus-4-7
+          GH_TOKEN: ${{ secrets.RESOLVE_ALERTS_PAT }}
+        run: claude --print --dangerously-skip-permissions "/resolve-github-alerts"

--- a/.github/workflows/resolve-github-alerts.yml
+++ b/.github/workflows/resolve-github-alerts.yml
@@ -18,6 +18,7 @@ jobs:
     name: Resolve alerts
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: security-alerts-bot
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs `/resolve-github-alerts` every Saturday at 16:00 UTC (9am PDT / 8am PST) and on manual dispatch.

Replaces the CCR remote-trigger routine, which couldn't complete because the CCR sandbox blocks direct `api.github.com` access and its MCP GitHub toolkit omits Dependabot / code-scanning / secret-scanning alert listings. Actions runners have `gh` pre-installed and reach GitHub's REST API with a PAT — the existing skill (`.claude/skills/resolve-github-alerts/SKILL.md`) runs unmodified.

## Required repo secrets

Before the workflow can run, add these at Settings → Secrets and variables → Actions:

- **`ANTHROPIC_API_KEY`** — Anthropic API key
- **`RESOLVE_ALERTS_PAT`** — fine-grained PAT scoped to this repo only, with:
  - Contents: read/write
  - Pull requests: read/write
  - Issues: read/write
  - Metadata: read
  - Dependabot alerts: read
  - Code scanning alerts: read
  - Secret scanning alerts: read

Used as `GH_TOKEN` for `gh` CLI calls and as the checkout token for git push.

## Safety model

- `--dangerously-skip-permissions` is required for non-interactive cron execution
- Real safety comes from (a) the PAT's tight repo-scoped permissions and (b) the skill's PR-only output — it opens PRs for review, never merges
- `concurrency.group` prevents overlapping runs
- 30-minute timeout caps runaway cost

## Test plan

- [ ] Add the two secrets
- [ ] Trigger manually via Actions → Resolve GitHub Security Alerts → Run workflow
- [ ] Verify the run completes without errors and produces a PR or "All Clear" report
- [ ] Let it run on its first scheduled Saturday

🤖 Generated with [Claude Code](https://claude.com/claude-code)