### PR TITLE
fix: resolve GitHub security alerts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
         entry: pip-audit
         args: [--skip-editable]
         language: python
-        additional_dependencies: [pip-audit==2.7.3, pip==26.0]
+        additional_dependencies: [pip-audit==2.7.3, pip==26.1]
         pass_filenames: false
         always_run: true
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,7 +2,7 @@
 -r requirements.txt
 
 # Build tools (required when using --generate-hashes)
-pip==26.0.1
+pip==26.1
 setuptools==82.0.1
 
 # Testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1910,9 +1910,9 @@ wheel==0.46.2 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.1 \
+    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
+    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3
     # via
     #   -r requirements-dev.in
     #   pip-api

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,5 +1,5 @@
 # Pin pip version with hashes for secure installation
 # This file is used in the Dockerfile to upgrade pip with hash verification
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.1 \
+    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
+    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3


### PR DESCRIPTION
## Summary

Automated resolution of GitHub security alerts.

| Alert | Package | Severity | Manifest | Fix |
| --- | --- | --- | --- | --- |
| #71 | pip | medium | `requirements-pip.txt` | 26.0.1 → 26.1 |
| #72 | pip | medium | `requirements-dev.txt` | 26.0.1 → 26.1 |

Both alerts are CVE-2026-3219 / GHSA-58qw-9mgm-455v — pip's handling of concatenated tar/ZIP files. The fix landed in [pypa/pip#13870](https://github.com/pypa/pip/pull/13870), milestone 26.1, merged 2026-04-19. GitHub's advisory still lists `first_patched_version: null` because it hasn't been updated to reflect the released fix yet, but pip 26.1 is published on PyPI and contains the patch.

## Changes

- `requirements-pip.txt`: pin `pip==26.1` with new hashes from PyPI
- `requirements-dev.in`: bump `pip==26.0.1` → `pip==26.1`
- `requirements-dev.txt`: regenerated via `make compile-requirements-dev`
- `.pre-commit-config.yaml`: bump the `pip-audit` hook's `additional_dependencies` from `pip==26.0` to `pip==26.1` so the hook environment itself isn't flagged

## Test Plan

- [ ] CI checks pass
- [ ] No new security alerts introduced
- [ ] Dependency compatibility verified (`make test` + `make lint` green locally)

Generated by `/resolve-github-alerts`