### PR TITLE
fix: resolve GitHub security alerts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1395,9 +1395,9 @@ python-dotenv==1.2.2 \
     # via
     #   -r requirements.txt
     #   pydantic-settings
-python-multipart==0.0.26 \
-    --hash=sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17 \
-    --hash=sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185
+python-multipart==0.0.27 \
+    --hash=sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645 \
+    --hash=sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602
     # via
     #   -r requirements.txt
     #   mcp

--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,4 @@ pyjwt[crypto]==2.12.0
 protobuf==5.29.6
 requests==2.33.1
 cryptography==46.0.7
-python-multipart==0.0.26
+python-multipart==0.0.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -763,9 +763,9 @@ python-dotenv==1.2.2 \
     # via
     #   -r requirements.in
     #   pydantic-settings
-python-multipart==0.0.26 \
-    --hash=sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17 \
-    --hash=sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185
+python-multipart==0.0.27 \
+    --hash=sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645 \
+    --hash=sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602
     # via
     #   -r requirements.in
     #   mcp


### PR DESCRIPTION
## Summary

Automated resolution of GitHub security alerts.

### Phase 1: Dependabot PRs

No open Dependabot PRs at run time.

### Phase 2: Dependabot Alerts

| Alert | Package | Severity | Action | Result |
| ----- | ------- | -------- | ------ | ------ |
| #73 | python-multipart | high | Bump 0.0.26 → 0.0.27 in `requirements.in`; regenerated `requirements-dev.txt` via `make compile-deps` | Fixed in this PR |
| #74 | python-multipart | high | Same fix; regenerated `requirements.txt` | Fixed in this PR |

### Phase 3: Code Scanning Alerts

| Alert | Rule | File | Action | Result |
| ----- | ---- | ---- | ------ | ------ |
| #77 | CVE-2026-42561 | `requirements.txt` | Same dep bump as Phase 2 (alert is the same CVE flagged by a different scanner) | Fixed in this PR |

### Phase 4: Secret Scanning Alerts

No open alerts.

### Totals

- Dependabot PRs ready to merge: 0
- Dependabot alerts fixed: 2
- Code scanning alerts fixed: 1
- Secret scanning alerts handled: 0
- Items requiring manual attention: 0

## Changes

- \`requirements.in\` — \`python-multipart==0.0.26\` → \`==0.0.27\`
- \`requirements.txt\` — regenerated via \`make compile-deps\`; new pin and SHA256 hashes for python-multipart 0.0.27
- \`requirements-dev.txt\` — regenerated via \`make compile-deps\` (inherits via \`-r requirements.txt\`)

## Test Plan

- [x] CI checks pass — local \`make lint\` (33 pre-commit hooks) all green
- [x] No new security alerts introduced — only python-multipart pin and hashes changed
- [x] Dependency compatibility verified — \`make test\` 35/35 passed locally

Generated by \`/resolve-github-alerts\`