### PR TITLE
fix: resolve GitHub security alerts (idna CVE-2026-45409)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -660,9 +660,9 @@ identify==2.6.15 \
     --hash=sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757 \
     --hash=sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf
     # via pre-commit
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via
     #   -r requirements.txt
     #   anyio

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ protobuf==5.29.6
 requests==2.33.1
 cryptography==46.0.7
 python-multipart==0.0.27
+idna==3.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -428,10 +428,11 @@ httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
     # via mcp
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via
+    #   -r requirements.in
     #   anyio
     #   httpx
     #   requests


### PR DESCRIPTION
## Summary

Automated resolution of GitHub security alerts.

Bumps `idna` from 3.11 to 3.15 to address [CVE-2026-45409](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) (GHSA-65pc-fj4g-8rjx, medium).

Resolves 2 Dependabot alerts (#81, #82) and 1 code-scanning alert (#80).

### Phase 1: Dependabot PRs
None open.

### Phase 2: Dependabot Alerts
| Alert | Package | Severity | Action | Result |
| ----- | ------- | -------- | ------ | ------ |
| #81 | idna | medium | Bump to 3.15 in requirements.in | Fixed in this PR |
| #82 | idna | medium | Bump to 3.15 in requirements.in | Fixed in this PR |

### Phase 3: Code Scanning Alerts
| Alert | Rule | File | Action | Result |
| ----- | ---- | ---- | ------ | ------ |
| #80 | CVE-2026-45409 | requirements.txt | Bump idna to 3.15 | Fixed in this PR |

### Phase 4: Secret Scanning Alerts
None open.

### Totals
- Dependabot PRs ready to merge: 0
- Dependabot alerts fixed: 2
- Code scanning alerts fixed: 1
- Secret scanning alerts handled: 0
- Items requiring manual attention: 0

## Changes

- Pin `idna==3.15` in `requirements.in` (transitive — pulled in by anyio, httpx, requests).
- Recompiled `requirements.txt` and `requirements-dev.txt` via `make compile-deps`.

## Test Plan

- [x] `make lint` passes (33 hooks including pip-audit)
- [x] `make test` passes (27 passed)
- [x] CI checks pass
- [x] No new security alerts introduced
- [x] Dependency compatibility verified

Generated by `/resolve-github-alerts`