### PR TITLE
fix: resolve GitHub security alerts

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -31,7 +31,7 @@ pre-commit==4.5.1
 # Publishing
 build==1.4.0
 twine==6.2.0
-sigstore==4.2.0
+sigstore==4.3.0
 
 # Dependency Management
 pip-tools==7.5.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1727,9 +1727,9 @@ securesystemslib==1.3.1 \
     --hash=sha256:2e5414bbdde33155a91805b295cbedc4ae3f12b48dccc63e1089093537f43c81 \
     --hash=sha256:ca915f4b88209bb5450ac05426b859d74b7cd1421cafcf73b8dd3418a0b17486
     # via tuf
-sigstore==4.2.0 \
-    --hash=sha256:bdbb49a42fd5f0ea6765919adb42ccee7254c482330764d0842eec4e11ad78d7 \
-    --hash=sha256:ed2e0f50aae85148a8aa4fc0f57c298927fce430ad1f988f38611ce90c85829f
+sigstore==4.3.0 \
+    --hash=sha256:0f60c46c92fd4e871fbec979c9ae2aa381d7a93fbb774e49c9964550e5e16856 \
+    --hash=sha256:3c4b566bddfcc53e73d3adc06acf4311d72be0d907a167133abdc815a472a59b
     # via -r requirements-dev.in
 sigstore-models==0.0.6 \
     --hash=sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e \
@@ -1825,9 +1825,9 @@ tqdm==4.67.1 \
     #   -r requirements.txt
     #   google-generativeai
     #   openai
-tuf==6.0.0 \
-    --hash=sha256:458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a \
-    --hash=sha256:9eed0f7888c5fff45dc62164ff243a05d47fb8a3208035eb268974287e0aee8d
+tuf==7.0.0 \
+    --hash=sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79 \
+    --hash=sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f
     # via sigstore
 twine==6.2.0 \
     --hash=sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8 \


### PR DESCRIPTION
## Summary

Automated resolution of GitHub security alerts.

### Phase 2: Dependabot Alerts
| Alert | Package | Severity | Action | Result |
| --- | --- | --- | --- | --- |
| #83 | tuf | medium | Bump sigstore 4.2.0 → 4.3.0 to unlock tuf 7.0.0 | Fixed |

`tuf` is a transitive dev dependency via `sigstore`. sigstore 4.2.0 capped it at `tuf~=6.0`; sigstore 4.3.0 allows `tuf>=6,<8`. Bumped `sigstore` in `requirements-dev.in` and recompiled `requirements-dev.txt` with `tuf` upgraded to 7.0.0 (the patched version).

## Changes

- `requirements-dev.in`: `sigstore==4.2.0` → `sigstore==4.3.0`
- `requirements-dev.txt`: recompiled — `sigstore==4.3.0`, `tuf==7.0.0` (only these two pins changed)

Both are dev/publishing-only dependencies (not shipped in `requirements.txt`).

## Test Plan

- [x] `make test` — 27 passed
- [x] `make lint` — all 33 hooks pass, including `pip-audit`
- [ ] CI checks pass
- [ ] No new security alerts introduced
- [ ] Dependency compatibility verified

Generated by `/resolve-github-alerts`